### PR TITLE
Added witer33/fiberpow

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ List of middlewares that are created by the Fiber community.
 - [elastic/apmfiber](https://github.com/elastic/apm-agent-go/tree/master/module/apmfiber) - APM Agent for Go Fiber.
 - [eozer/fiber_ldapauth](https://github.com/eozer/fiber_ldapauth) - LDAP Authentication Middleware for Fiber.
 - [darkweak/souin](https://github.com/darkweak/souin) - HTTP cache, RFC compliant, alternative to Varnish available as a middleware.
+- [witer33/fiberpow](https://github.com/witer33/fiberpow) - Anti DDoS/Bot Middleware with a customizable Proof Of Work challenge.
 
 
 ## 🚧 Boilerplates


### PR DESCRIPTION
https://github.com/witer33/fiberpow is a brand new middleware, that easily permits to block DDoS attacks or at least slow them. It uses a simple Proof Of Work challenge using SHA-256, similar to cryptos, to limit requests from a specific machine.
I would love to add this to awesome-fiber, and hopefully help people with bots issues.