### PR TITLE
Add airbrake middleware to third party list

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ List of middlewares that are created by the Fiber community.
 - [witer33/fiberpow](https://github.com/witer33/fiberpow) - Anti DDoS/Bot Middleware with a customizable Proof Of Work challenge.
 - [joffref/opa-middleware](https://github.com/Joffref/opa-middleware) - Provides an OPA middleware integration for fiber.
 - [vladfr/fiber-servertiming](https://github.com/vladfr/fiber-servertiming) - A middleware to add Server-Timing headers based on the W3C Server-Timing Spec.
+- [airbrake/gobrake](https://github.com/airbrake/gobrake/tree/master/examples/fiber) - An Airbrake middleware that reports performance data (route stats).
 
 ## 🚧 Boilerplates
 Premade boilerplates for Fiber.


### PR DESCRIPTION
Found this Fiber middleware while browsing Github a few days ago. 