### PR TITLE
Add ZEISS middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ List of middlewares that are created by the Fiber community.
 - [mikhail-bigun/fiberlogrus](https://github.com/mikhail-bigun/fiberlogrus) - A logger middleware that uses logrus and its structured logging features.
 - [Idan-Fishman/fiber-bind](https://github.com/Idan-Fishman/fiber-bind) - Request schema validator middleware that validates sources such as the request body, query string parameters, route parameters and even form files.
 - [rodrigoodhin/fiper](https://gitlab.com/rodrigoodhin/fiper) - FiPer is a library that provides Fiber with Role Based Access Control (RBAC) using JWT and with database persistence using two ORM libraries are supported: Gorm and Bun.
+- [zeiss/fiber-goth](https://github.com/ZEISS/fiber-goth) -  Simple middleware to integrate authentication to your Fiber applications.
+- [zeiss/fiber-authz](https://github.com/ZEISS/fiber-authz) - A middleware to secure routes in Fiber with a defined RBAC model.
+- [zeiss/fiber-htmx](https://github.com/ZEISS/fiber-htmx) - A middleware for using HTMX in Fiber.
 
 ## 🚧 Boilerplates
 Premade boilerplates for Fiber.


### PR DESCRIPTION
Add the three middlewares created by https://github.com/ZEISS to awesome-fiber

- https://github.com/ZEISS/fiber-goth
- https://github.com/ZEISS/fiber-authz
- https://github.com/ZEISS/fiber-htmx