### PR TITLE
Add streamerd/fibergun to Third Party

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ List of middlewares that are created by the Fiber community.
 - [zeiss/fiber-authz](https://github.com/ZEISS/fiber-authz) - A middleware to secure routes in Fiber with a defined RBAC model.
 - [zeiss/fiber-htmx](https://github.com/ZEISS/fiber-htmx) - A middleware for using HTMX in Fiber.
 - [jsorb84/ssefiber](https://github.com/jsorb84/ssefiber) - A basic SSE Implementation for Fiber.
+- [streamerd/fibergun](https://github.com/streamerd/fibergun) - A GunDB middleware for Fiber. Enables easy integration of GunDB, a decentralized database.
 
 ## 🚧 Boilerplates
 Premade boilerplates for Fiber.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new middleware entry for "fibergun," facilitating GunDB integration within the Fiber web framework.
- **Documentation**
	- Updated the README.md to include the new middleware in the "Third Party" section, enhancing clarity and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->