### PR TITLE
add opentelemetry-go-auto-instrumentation tool for fiber

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Several tools to make Fiber usage easier.
 - [tompston/gomakeme](https://github.com/tompston/gomakeme) - Generate boilerplate + endpoints for Fiber or Gin REST APIs.
 - [ryanbekhen/feserve](https://github.com/ryanbekhen/feserve) - Feserve is a lightweight application or docker image to serve frontend and load balancer applications.
 - [deepmap/oapi-codegen](https://github.com/deepmap/oapi-codegen) - Generate Go client and server boilerplate from OpenAPI 3 specifications.
+- [Alibaba/opentelemetry-go-auto-instrumentation](https://github.com/alibaba/opentelemetry-go-auto-instrumentation) - A tool to monitor fiber application without changing any code with OpenTelemetry APIs.
 
 ## 📖 Articles
 


### PR DESCRIPTION
related to https://github.com/gofiber/fiber/issues/3245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Tools section in the documentation to include a monitoring solution for Fiber applications, which utilizes OpenTelemetry APIs without requiring code modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->