### PR TITLE
added go-htmx-starter to boilerplates

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Premade boilerplates for Fiber.
 - [embedmode/fiberseed](https://github.com/embedmode/fiberseed) - Fiber boilerplate api with many middlewares.
 - [GalvinGao/gofiber-template](https://github.com/GalvinGao/gofiber-template) - A production-ready, container-first opinionated gofiber project template. Config by envvars, DI by go.uber.org/fx, Database by uptrace/bun, with out-of-the-box MVC folder structure and CI/CD support.
 - [mikhail-bigun/go-app-template](https://github.com/mikhail-bigun/go-app-template) - Clean architecture Go application boilerplate with enriched Fiber implementation.
+- [felipeafonso/go-htmx-starter](https://github.com/FelipeAfonso/go-htmx-starter) - A front-end opinionated boilerplate for Go + HTMX development, using Tailwind and Vite for Bundling and Hot Reloading.
 - [amrebada/go-modules](https://github.com/amrebada/go-modules) - Nest JS like structure for Go Fiber.
 - [ingeniousambivert/fiber-bootstrapped](https://github.com/ingeniousambivert/fiber-bootstrapped) - A toolkit for Go projects embracing a service-centric architecture, inspired by the principles of FeathersJS.
 - [sebajax/go-vertical-slice-architecture](https://github.com/sebajax/go-vertical-slice-architecture) - Vertical Slice Architecture code archetype using Fiber and Uber dig. A maintainable, and scalable code organization.


### PR DESCRIPTION
Hey guys, I've been using Fiber as the backbone of my current front-end starter for the last two months, and I figured it'd be a good fit for the Boilerplates. 

This is a front-end first boilerplate for creating web applications using HTMX/Tailwind. It uses Bun and Vite to handle JS stuff, and I'm proud of the dev experience I achieved with it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded available project boilerplate options by including a new front-end opinionated boilerplate for Go + HTMX development, featuring Tailwind and Vite for bundling and hot reloading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->