### PR TITLE
Add Apitally to Third Party section

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ List of middlewares that are created by the Fiber community.
 - [zeiss/fiber-htmx](https://github.com/ZEISS/fiber-htmx) - A middleware for using HTMX in Fiber.
 - [jsorb84/ssefiber](https://github.com/jsorb84/ssefiber) - A basic SSE Implementation for Fiber.
 - [streamerd/fibergun](https://github.com/streamerd/fibergun) - A GunDB middleware for Fiber. Enables easy integration of GunDB, a decentralized database.
+- [apitally/apitally-go](https://github.com/apitally/apitally-go) - Simple API monitoring tool for Fiber. Tracks API usage, errors, and performance, and includes request logging and alerting features.
 
 ## 🚧 Boilerplates
 


### PR DESCRIPTION
Add [Apitally](https://apitally.io/fiber) to the Third Party section.

Apitally is a lightweight monitoring and analytics tool that helps developers track API usage, performance, and errors with minimal setup. It also includes request logging and alerting features.

Support for Fiber was added recently. See setup guide here:
https://docs.apitally.io/frameworks/fiber

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added "apitally/apitally-go" to the list of third-party middlewares in the documentation, highlighting its features for API monitoring, usage tracking, error detection, and alerting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->