### PR TITLE
add fiberopenapi at thirdparty fiber

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ List of middlewares that are created by the Fiber community.
 - [newrelic/go-agent](https://github.com/newrelic/go-agent/tree/master/v3/integrations/nrfiber) - Official New Relic middleware for Fiber that manages instrumentation for New Relic monitoring.
 - [narmadaweb/limiter](https://github.com/narmadaweb/limiter) - A high-performance Redis-backed rate limiter middleware for Fiber, supporting fixed window, sliding window, and token bucket algorithms.
 - [narmadaweb/gonify](https://github.com/narmadaweb/gonify) - Fiber Minifying middleware for HTML5, CSS3, JavaScript, Json, XML and SVG.
+- [oaswrap/fiberopenapi](https://github.com/oaswrap/spec/tree/main/adapter/fiberopenapi) - Fiber adapter for OpenAPI 3.x specification generation with automatic route documentation.
 
 ## 🚧 Boilerplates
 


### PR DESCRIPTION
[fiberopenapi](https://github.com/oaswrap/spec/tree/main/adapter/fiberopenapi) - Fiber adapter for OpenAPI 3.x specification generation with automatic route documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new third-party tool reference for generating OpenAPI 3.x specifications and automatic route documentation (Fiber adapter).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->